### PR TITLE
Minor changes made for testing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 --------
 
  - Hotfix to accommodate change in padding computation in ppxf>=6.7.15
+ - Allow emission-line moment, modeling, and spectral-index keys to be
+   None, meaning that the DAP only fits the stellar kinematics but still
+   produces the MAPS and LOGCUBE files.
+ - Fixed bug in templates when using iteration_mode = 'global_template'
 
 TODO:
  - Documentation of config examples are out of date!

--- a/python/mangadap/proc/ppxffit.py
+++ b/python/mangadap/proc/ppxffit.py
@@ -1587,7 +1587,8 @@ class PPXFFit(StellarKinematicsFit):
 #        return ppxf_fit
 
 
-    def _fit_dispersion_correction(self, result, baseline_dispersion=None):
+    def _fit_dispersion_correction(self, templates, templates_rfft, result,
+                                   baseline_dispersion=None):
         """
         Calculate the dispersion correction:
           - Construct the optimized, redshifted template *without* the
@@ -1611,8 +1612,8 @@ class PPXFFit(StellarKinematicsFit):
         # difference
         model_wlosvd = numpy.ma.empty(self.obj_flux.shape, dtype=float)
         model_wlosvd_msres = numpy.ma.empty(self.obj_flux.shape, dtype=float)
-        model_template = numpy.empty((self.nobj, self.tpl_flux.shape[1]), dtype=float)
-        model_template_rfft = numpy.empty((self.nobj, self.tpl_rfft.shape[1]), dtype=complex)
+        model_template = numpy.empty((self.nobj, templates.shape[1]), dtype=float)
+        model_template_rfft = numpy.empty((self.nobj, templates_rfft.shape[1]), dtype=complex)
         start = numpy.empty(self.nobj, dtype=int)
         end = numpy.empty(self.nobj, dtype=int)
         guess_kin = self.guess_kin.copy()
@@ -1649,14 +1650,14 @@ class PPXFFit(StellarKinematicsFit):
                 nominal_par, _moments, vj = self._fill_ppxf_par(numpy.array([0.0,
                                                                             nominal_dispersion[i]]))
                 nominal_losvd_kernel_rfft = ppxf.losvd_rfft(nominal_par, 1, _moments,
-                                                            self.tpl_rfft.shape[1], 1, 0.0,
+                                                            templates_rfft.shape[1], 1, 0.0,
                                                             self.velscale_ratio, 0.0)[:,0,0]
 
                 # Get the composite template
                 model_template[i,:] = numpy.dot(result[i].tplwgt,
-                                                self.tpl_flux[result[i].tpl_to_use,:])
+                                                templates[result[i].tpl_to_use,:])
                 model_template_rfft[i,:] = numpy.dot(result[i].tplwgt,
-                                                     self.tpl_rfft[result[i].tpl_to_use,:])
+                                                     templates_rfft[result[i].tpl_to_use,:])
 
                 # Convolve the template to the fitted velocity dispersion
                 tmp_wlosvd = numpy.fft.irfft(model_template_rfft[i,:]*nominal_losvd_kernel_rfft,
@@ -1866,7 +1867,8 @@ class PPXFFit(StellarKinematicsFit):
         model_par['MASK'][indx] = self.bitmask.turn_on(model_par['MASK'][indx], 'BAD_SIGMA')
 
 
-    def _save_results(self, global_fit_result, result, model_mask, model_par):
+    def _save_results(self, global_fit_result, templates, templates_rfft, result, model_mask,
+                      model_par):
 
         #---------------------------------------------------------------
         # Get the model spectra
@@ -2031,8 +2033,9 @@ class PPXFFit(StellarKinematicsFit):
         # TODO: Get the velocity dispersion corrections here and above
         # regardless of the resolution matching?
         if not self.matched_resolution:
-            model_par['SIGMACORR_EMP'], err = self._fit_dispersion_correction(
-                                                            result, baseline_dispersion=100)
+            model_par['SIGMACORR_EMP'], err \
+                    = self._fit_dispersion_correction(templates, templates_rfft, result,
+                                                      baseline_dispersion=100)
             if numpy.sum(err) > 0:
                 model_par['MASK'][err] = self.bitmask.turn_on(model_par['MASK'][err],
                                                               'BAD_SIGMACORR_EMP')
@@ -2541,7 +2544,7 @@ class PPXFFit(StellarKinematicsFit):
         # Initialize the template set according to the iteration mode
         if self._mode_uses_global_template():
             templates = numpy.dot(global_fit_result.tplwgt, self.tpl_flux).reshape(1,-1)
-            tpl_to_use = numpy.ones(1, dtype=numpy.bool)
+            tpl_to_use = numpy.ones((self.nobj,1), dtype=numpy.bool)
             templates_rfft = numpy.fft.rfft(templates, self.tpl_npad, axis=1)
         elif self._mode_uses_nonzero_templates():
             templates = self.tpl_flux
@@ -2570,7 +2573,8 @@ class PPXFFit(StellarKinematicsFit):
         #---------------------------------------------------------------
         # Save the results
         model_flux, model_mask, model_par \
-                = self._save_results(global_fit_result, result, model_mask, model_par)
+                = self._save_results(global_fit_result, templates, templates_rfft, result,
+                                     model_mask, model_par)
 
         if not self.quiet:
             log_output(self.loggers, 1, logging.INFO, 'pPXF finished')

--- a/python/mangadap/survey/manga_dap.py
+++ b/python/mangadap/survey/manga_dap.py
@@ -199,11 +199,13 @@ def manga_dap(obs, plan, dbg=False, log=None, verbose=0, drpver=None, redux_path
         #   - SpectralIndices
         bin_method = SpatiallyBinnedSpectra.define_method(plan['bin_key'][i])
         sc_method = StellarContinuumModel.define_method(plan['continuum_key'][i])
-        el_method = EmissionLineModel.define_method(plan['elfit_key'][i])
+        el_method = None if plan['elfit_key'][i] is None \
+                            else EmissionLineModel.define_method(plan['elfit_key'][i])
 
         method = defaults.default_dap_method(bin_method['key'],
                                              sc_method['fitpar']['template_library_key'],
-                                             el_method['continuum_tpl_key'])
+                                             'None' if el_method is None
+                                                else el_method['continuum_tpl_key'])
         method_dir = defaults.default_dap_method_path(method, plate=obs['plate'],
                                                       ifudesign=obs['ifudesign'], drpver=drpver,
                                                       dapver=dapver, analysis_path=_analysis_path)

--- a/python/mangadap/survey/rundap.py
+++ b/python/mangadap/survey/rundap.py
@@ -462,10 +462,12 @@ class rundap:
         for p in self.plan:
             bin_method = SpatiallyBinnedSpectra.define_method(p['bin_key'])
             sc_method = StellarContinuumModel.define_method(p['continuum_key'])
-            el_method = EmissionLineModel.define_method(p['elfit_key'])
+            el_method = None if p['elfit_key'] is None \
+                                else EmissionLineModel.define_method(p['elfit_key'])
             self.daptypes += [defaults.default_dap_method(bin_method['key'],
                                                     sc_method['fitpar']['template_library_key'],
-                                                    el_method['continuum_tpl_key'])]
+                                                    'None' if el_method is None else
+                                                            el_method['continuum_tpl_key'])]
         if len(numpy.unique(self.daptypes)) != self.plan.nplans:
             raise ValueError('Plans in {0} do not yield unique DAPTYPEs.'.format(self.plan_file))
 


### PR DESCRIPTION
The PR incorporates some changes made during tests done for the DAP overview paper:

 - Keywords for emission-line moment calculations and model fitting and spectral-index fitting can be None, meaning that the DAP will only fit the stellar kinematics, but not fault when producing the MAPS and model cube output files.
 - Fixed a bug when handling the templates when the stellar kinematics mode that uses a single global template is selected.