### PR TITLE
Reject outlier emission-line moment measurements when used as input guess for emission-line modeling

### DIFF
--- a/examples/fit_one_spec.py
+++ b/examples/fit_one_spec.py
@@ -338,7 +338,7 @@ def main():
 
     # Get the stellar continuum that was fit for the emission lines
     elcmask = eml_mask.ravel() > 0
-    goodpix = numpy.arange(elcmask.size)[numpy.invert(elcmask)]
+    goodpix = numpy.arange(elcmask.size)[numpy.logical_not(elcmask)]
     start, end = goodpix[0], goodpix[-1]+1
     elcmask[start:end] = False
     el_continuum = numpy.ma.MaskedArray(model_flux - eml_flux,

--- a/mangadap/config/manga.py
+++ b/mangadap/config/manga.py
@@ -539,7 +539,7 @@ class MaNGAConfig:
 
         # Build the spectral resolution vectors
         if 'SPECRES' in _ext:
-            sres = numpy.ma.MaskedArray(hdu[_ext].data, mask=numpy.invert(hdu[_ext].data > 0))
+            sres = numpy.ma.MaskedArray(hdu[_ext].data, mask=numpy.logical_not(hdu[_ext].data > 0))
             if fill:
                 sres = numpy.ma.MaskedArray(interpolate_masked_vector(sres))
             if not median:
@@ -550,7 +550,7 @@ class MaNGAConfig:
         # Otherwise dealing with the DISP data
         sres = numpy.ma.MaskedArray(hdu[_ext].data)
         # Mask any non-positive value
-        sres[numpy.invert(sres > 0)] = numpy.ma.masked
+        sres[numpy.logical_not(sres > 0)] = numpy.ma.masked
         # Convert from sigma in angstroms to spectral resolution (based
         # on FWHM). Make sure to treat array shapes correctly for the
         # different modes.

--- a/mangadap/dapfits.py
+++ b/mangadap/dapfits.py
@@ -271,8 +271,8 @@ class construct_maps_file:
                     or self.hdu[f'{e}_MASK'].data is None \
                     or self.hdu[f'{e}_IVAR'].data is None:
                 continue
-            indx = numpy.invert(self.bitmask.flagged(self.hdu['{0}_MASK'.format(e)].data)) \
-                            & numpy.invert(self.hdu['{0}_IVAR'.format(e)].data > 0)
+            indx = numpy.logical_not(self.bitmask.flagged(self.hdu['{0}_MASK'.format(e)].data)) \
+                            & numpy.logical_not(self.hdu['{0}_IVAR'.format(e)].data > 0)
             if numpy.sum(indx) > 0:
                 self.hdu['{0}_MASK'.format(e)].data[indx] \
                     = self.bitmask.turn_on(self.hdu['{0}_MASK'.format(e)].data[indx], 'MATHERROR')
@@ -1674,7 +1674,7 @@ class construct_cube_file:
         return prihdr, DAPFitsUtil.list_of_image_hdus(data, hdr, ext)
 
     def _set_no_model(self, mask):
-        indx = numpy.arange(len(mask))[numpy.invert(mask > 0)]
+        indx = numpy.arange(len(mask))[numpy.logical_not(mask > 0)]
         if len(indx) == 0:
             return mask
         mask[:indx[0]] = self.bitmask.turn_on(mask[:indx[0]], 'NOMODEL')
@@ -1954,7 +1954,7 @@ def add_snr_metrics_to_header(hdr, cube, r_re):
             covar = cube.covariance_matrix(covar_channel)
 
         # Get the spaxels within the radius limits
-        indx = numpy.arange(r_re.size)[(r_re > 1) & (r_re < 1.5) & numpy.invert(signal.mask)]
+        indx = numpy.arange(r_re.size)[(r_re > 1) & (r_re < 1.5) & numpy.logical_not(signal.mask)]
         if len(indx) == 0:
             hdr[key_med[i]] = (0., com_med[i])
             hdr[key_ring[i]] = (0., com_ring[i])

--- a/mangadap/datacube/datacube.py
+++ b/mangadap/datacube/datacube.py
@@ -680,7 +680,7 @@ class DataCube:
                                                 missing_bins=missing_bins, unique_bins=unique_bins)
         # For this approach, the wavelengths masked should be
         # *identical* for all spectra
-        nwave = numpy.sum(numpy.invert(numpy.ma.getmaskarray(masked_data)), axis=1)
+        nwave = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(masked_data)), axis=1)
         # No masking should be present except for the wavelength range
         # meaning that the number of unmasked pixels at all spatial
         # positions should be the same.
@@ -969,9 +969,9 @@ class DataCube:
                                     axis=1) / norm
             return float(numpy.ma.mean(cen_wave))
 
-        norm = numpy.ma.sum(numpy.invert(numpy.ma.getmaskarray(flux))
+        norm = numpy.ma.sum(numpy.logical_not(numpy.ma.getmaskarray(flux))
                             * _response_func[None,:] * dw[None,:], axis=1)
-        cen_wave = numpy.ma.sum(numpy.invert(numpy.ma.getmaskarray(flux)) * self.wave[None,:]
+        cen_wave = numpy.ma.sum(numpy.logical_not(numpy.ma.getmaskarray(flux)) * self.wave[None,:]
                                 * _response_func[None,:] * dw[None,:], axis=1) / norm
         return float(numpy.ma.mean(cen_wave))
 
@@ -1034,7 +1034,7 @@ class DataCube:
         _response_func = self.interpolate_to_match(response_func)
 
         # Calculate the statistics and return
-        response_integral = numpy.sum(numpy.invert(numpy.ma.getmaskarray(flux))
+        response_integral = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(flux))
                                         * (_response_func*dw)[None,:], axis=1)
         signal = numpy.ma.divide(numpy.ma.sum(flux*(_response_func*dw)[None,:], axis=1),
                                  response_integral).reshape(self.spatial_shape)

--- a/mangadap/proc/bandpassfilter.py
+++ b/mangadap/proc/bandpassfilter.py
@@ -377,7 +377,7 @@ def passband_integrated_width(x, y, passband=None, borders=False, log=False, bas
     Determine the integrated width of the passband, accounting for masked pixels.
     """
     unity = y.copy()
-    unity[numpy.invert(numpy.ma.getmaskarray(y))] = 1.0
+    unity[numpy.logical_not(numpy.ma.getmaskarray(y))] = 1.0
     return passband_integral(x, unity, passband=passband, borders=borders, log=log, base=base)
 
 
@@ -389,7 +389,7 @@ def passband_integrated_mean(x, y, err=None, passband=None, borders=False, log=F
     # Get the passband interval, accounting for masked pixels
     interval = passband_integrated_width(x, y, passband=passband, borders=borders, log=log,
                                          base=base)
-    interval = numpy.ma.MaskedArray(interval, mask=numpy.invert(numpy.absolute(interval) > 0))
+    interval = numpy.ma.MaskedArray(interval, mask=numpy.logical_not(numpy.absolute(interval) > 0))
 
     # Get the integral of y over the passband
     integral = numpy.ma.MaskedArray(passband_integral(x, y, passband=passband, borders=borders,
@@ -442,7 +442,7 @@ def passband_weighted_mean(x, y, z, passband=None, borders=False, yerr=None, zer
     weighted_integral = passband_integral(x, z*y, passband=passband, borders=borders, log=log,
                                           base=base)
     integral = passband_integral(x, y, passband=passband, borders=borders, log=log, base=base)
-    integral = numpy.ma.MaskedArray(integral, mask=numpy.invert(numpy.absolute(integral) > 0))
+    integral = numpy.ma.MaskedArray(integral, mask=numpy.logical_not(numpy.absolute(integral) > 0))
 
     if yerr is None and zerr is None:
         return numpy.ma.divide(weighted_integral,integral), None
@@ -577,7 +577,7 @@ def pseudocontinuum(x, y, passband=None, err=None, log=True, weighted_center=Fal
                             / numpy.diff(passband, axis=1).ravel()
 
     return band_center, continuum, continuum_error, interval_frac < 1.0, \
-                numpy.invert(interval_frac > 0.0)
+                numpy.logical_not(interval_frac > 0.0)
 
 
 def emission_line_equivalent_width(wave, flux, bluebands, redbands, line_centroid, line_flux,

--- a/mangadap/proc/elric.py
+++ b/mangadap/proc/elric.py
@@ -219,7 +219,7 @@ class LineProfileFit:
         self.bounds = (-numpy.inf, numpy.inf) if bounds is None else bounds
 
         # Get the number of free parameters
-        self.nfitpar = numpy.sum(numpy.invert(self.fixed))
+        self.nfitpar = numpy.sum(numpy.logical_not(self.fixed))
 
         # Construct the model
         self.model = _profile_list[0].profile
@@ -252,7 +252,7 @@ class LineProfileFit:
         """
         if len(par) not in [ self.npar, self.nfitpar ]:
             raise ValueError('Incorrect number of parameters provided')
-        self.par[numpy.invert(self.fixed)] = par[numpy.invert(self.fixed)] \
+        self.par[numpy.logical_not(self.fixed)] = par[numpy.logical_not(self.fixed)] \
                                                     if len(par) == self.npar else par
         # Then tie parameters...
 
@@ -320,7 +320,7 @@ class LineProfileFit:
             _mask |= mask
 
         # Set the internal vectors to be numpy.ndarrays that only include the unmasked values
-        indx = numpy.invert(_mask)
+        indx = numpy.logical_not(_mask)
         self.x = numpy.array(x[indx])
         self.y = numpy.array(y[indx])
         self.err = None if error is None else numpy.array(error[indx])
@@ -885,22 +885,22 @@ class Elric(EmissionLineFit):
         """
 #        print('par: ', par)
 #        print('lbnd: ', lbnd)
-        lbounded = numpy.invert(numpy.isinf(lbnd))
+        lbounded = numpy.logical_not(numpy.isinf(lbnd))
 #        print('L bounded: ', lbounded)
 
 #        print('ubnd: ', ubnd)
-        ubounded = numpy.invert(numpy.isinf(ubnd))
+        ubounded = numpy.logical_not(numpy.isinf(ubnd))
 #        print('U bounded: ', ubounded)
 
         if numpy.sum(lbounded) == 0 and numpy.sum(ubounded) == 0:
 #            print('No bounds')
             return False
 
-        if numpy.any(lbounded & numpy.invert(ubounded) & (par - lbnd < atol)):
+        if numpy.any(lbounded & numpy.logical_not(ubounded) & (par - lbnd < atol)):
 #            print('Near lower bound')
             return True
 
-        if numpy.any(numpy.invert(lbounded) & ubounded & (ubnd - par < atol)):
+        if numpy.any(numpy.logical_not(lbounded) & ubounded & (ubnd - par < atol)):
 #            print('Near upper bound')
             return True
 
@@ -916,7 +916,7 @@ class Elric(EmissionLineFit):
         Dp = numpy.zeros(ulbounded.size, dtype=float)
         indx = ulbounded & logbounded
         Dp[indx] = numpy.log10(ubnd[indx]) - numpy.log10(lbnd[indx])
-        indx = ulbounded & numpy.invert(logbounded)
+        indx = ulbounded & numpy.logical_not(logbounded)
         Dp[indx] = ubnd[indx] - lbnd[indx]
         tol = Dp*rtol
 #        print(tol)
@@ -933,7 +933,7 @@ class Elric(EmissionLineFit):
 #        print((par - lbnd)[ulbounded & ~logbounded])
 #        print((ubnd - par)[ulbounded & ~logbounded])
 
-        if numpy.any(ulbounded & numpy.invert(logbounded) & ((par-lbnd < tol) | (ubnd-par < tol))):
+        if numpy.any(ulbounded & numpy.logical_not(logbounded) & ((par-lbnd < tol) | (ubnd-par < tol))):
 #            print('Near boundary in linear')
             return True
 #        print('Not near boundary')
@@ -1050,7 +1050,7 @@ class Elric(EmissionLineFit):
         if self.error is not None:
             tmperr = numpy.diag(self.bestfit[i,j].cov)
             if not numpy.any(tmperr < 0):
-                model_fit_par['ERR'][i,j,numpy.invert(model_fit_par['FIXED'][i,j])] \
+                model_fit_par['ERR'][i,j,numpy.logical_not(model_fit_par['FIXED'][i,j])] \
                         = numpy.sqrt(numpy.diag(self.bestfit[i,j].cov))
             else:
                 model_fit_par['MASK'][i,j] = self.bitmask.turn_on(model_fit_par['MASK'][i,j],
@@ -1405,7 +1405,7 @@ class Elric(EmissionLineFit):
 
             # Set the mask for any pixels that are NEVER fit for this
             # spectrum
-            indx = numpy.invert(numpy.any(fitting_mask, axis=0))
+            indx = numpy.logical_not(numpy.any(fitting_mask, axis=0))
             model_mask[i,indx] = self.bitmask.turn_on(model_mask[i,indx], 'OUTSIDE_RANGE')
 
             model_jump = numpy.array([
@@ -1593,7 +1593,7 @@ class Elric(EmissionLineFit):
                                                    self.fitting_window[j].profile_set.tolist(),
                                             error=None if self.error is None else self.error[i,:],
                                                    base_order=base_order,
-                                                   mask=numpy.invert(fitting_mask[j,:]),
+                                                   mask=numpy.logical_not(fitting_mask[j,:]),
                                                    par=_guess_par,
                                                    bounds=(_bounds[:,0], _bounds[:,1]),
                                                    construct_covariance=True)
@@ -1650,7 +1650,7 @@ class Elric(EmissionLineFit):
 #            print('Windows with parameters near boundary: {0}'.format(total_near_bound))
 
             # Determine the instrumental dispersion correction at the line centers
-            indx = numpy.invert(self.bitmask.flagged(model_eml_par['MASK'][i,:],
+            indx = numpy.logical_not(self.bitmask.flagged(model_eml_par['MASK'][i,:],
                                                      flag=['INSUFFICIENT_DATA', 'FIT_FAILED',
                                                            'NEAR_BOUND', 'UNDEFINED_COVAR' ]))
             model_eml_par['SIGMACORR'][i,indx] \

--- a/mangadap/proc/sasuke.py
+++ b/mangadap/proc/sasuke.py
@@ -1168,8 +1168,8 @@ class Sasuke(EmissionLineFit):
         # - Otherwise, flag the full fit (parameters and model) as
         #   NEAR_BOUND if all the parameters are near the boundary but
         #   not the lower sigma boundary
-        indx = numpy.all( (near_lower_bound & numpy.invert(sig_indx)[None,:])
-                            | (near_bound & numpy.invert(near_lower_bound)), axis=1)
+        indx = numpy.all( (near_lower_bound & numpy.logical_not(sig_indx)[None,:])
+                            | (near_bound & numpy.logical_not(near_lower_bound)), axis=1)
         if numpy.sum(indx) > 0:
             model_fit_par['MASK'][indx] = self.bitmask.turn_on(model_fit_par['MASK'][indx],
                                                                'NEAR_BOUND')
@@ -1177,7 +1177,7 @@ class Sasuke(EmissionLineFit):
 
         # - Flag the spectrum was not fit
         if not numpy.all(spec_to_fit):
-            indx = numpy.invert(spec_to_fit)
+            indx = numpy.logical_not(spec_to_fit)
             model_fit_par['MASK'][indx] = self.bitmask.turn_on(model_fit_par['MASK'][indx],
                                                                'NO_FIT')
 #            model_mask[indx,:] = self.bitmask.turn_on(model_mask[indx,:], 'NO_FIT')
@@ -1235,8 +1235,8 @@ class Sasuke(EmissionLineFit):
             # - Determine if any of the kinematic parameters are near
             #   the bound (excluding the lower velocity dispersion
             #   limit)
-            flg = numpy.any((near_lower_bound[:,indx] & numpy.invert(sig_indx)[None,indx])
-                                | (near_bound[:,indx] & numpy.invert(near_lower_bound[:,indx])),
+            flg = numpy.any((near_lower_bound[:,indx] & numpy.logical_not(sig_indx)[None,indx])
+                                | (near_bound[:,indx] & numpy.logical_not(near_lower_bound[:,indx])),
                             axis=1)
             if numpy.sum(flg) > 0:
                 model_eml_par['MASK'][flg,j] = self.bitmask.turn_on(model_eml_par['MASK'][flg,j],
@@ -1246,8 +1246,8 @@ class Sasuke(EmissionLineFit):
         model_mask[flux.mask] = self.bitmask.turn_on(model_mask[flux.mask], flag='DIDNOTUSE')
 
         # Mask any lines that were not fit
-        model_eml_par['MASK'][:,numpy.invert(self.fit_eml)] \
-                    = self.bitmask.turn_on(model_eml_par['MASK'][:,numpy.invert(self.fit_eml)],
+        model_eml_par['MASK'][:,numpy.logical_not(self.fit_eml)] \
+                    = self.bitmask.turn_on(model_eml_par['MASK'][:,numpy.logical_not(self.fit_eml)],
                                            flag='NO_FIT')
 
         #---------------------------------------------------------------
@@ -2370,7 +2370,11 @@ class Sasuke(EmissionLineFit):
         for i,(s,e) in enumerate(zip(start,end)):
             if not spec_to_fit[i]:
                 continue
-            model_mask[i,:s] = self.bitmask.turn_on(model_mask[i,:s], 'DIDNOTUSE')
+            try:
+                model_mask[i,:s] = self.bitmask.turn_on(model_mask[i,:s], 'DIDNOTUSE')
+            except:
+                embed()
+                exit()
             model_mask[i,e:] = self.bitmask.turn_on(model_mask[i,e:], 'DIDNOTUSE')
 
         #---------------------------------------------------------------
@@ -2451,7 +2455,7 @@ class Sasuke(EmissionLineFit):
 
         # Flag pixels that weren't in the fitted range
         if not numpy.all(spec_to_fit):
-            indx = numpy.invert(spec_to_fit)
+            indx = numpy.logical_not(spec_to_fit)
             model_mask[indx,:] = self.bitmask.turn_on(model_mask[indx,:], 'DIDNOTUSE')
 
         # Flag failed fits
@@ -2563,7 +2567,7 @@ class Sasuke(EmissionLineFit):
         smoments = model_fit_par['KIN'].shape[1] - 2*ngas_comp
 
         # Only produce selected models
-        skip = numpy.zeros(nobj, dtype=bool) if select is None else numpy.invert(select)
+        skip = numpy.zeros(nobj, dtype=bool) if select is None else numpy.logical_not(select)
 
         # Instantiate the output model array
         models = numpy.ma.zeros(_obj_flux.shape, dtype=float)

--- a/mangadap/proc/spatialbinning.py
+++ b/mangadap/proc/spatialbinning.py
@@ -315,7 +315,7 @@ class RadialBinning(SpatialBinning):
 
         if gpm is not None:
             # Remove any masked pixels
-            binid[gpm] = -1
+            binid[numpy.logical_not(gpm)] = -1
 
         return binid
 

--- a/mangadap/proc/spatiallybinnedspectra.py
+++ b/mangadap/proc/spatiallybinnedspectra.py
@@ -553,12 +553,12 @@ class SpatiallyBinnedSpectra:
 
         # Turn on the flag stating that the number of valid channels in
         # the spectrum was below the input fraction.
-        indx = numpy.array([numpy.invert(good_fgoodpix).reshape(self.spatial_shape).T]*self.nwave).T
+        indx = numpy.array([numpy.logical_not(good_fgoodpix).reshape(self.spatial_shape).T]*self.nwave).T
         mask[indx] = self.bitmask.turn_on(mask[indx], flag='LOW_SPECCOV')
 
         # Turn on the flag stating that the S/N in the spectrum was
         # below the requested limit
-        indx = numpy.array([numpy.invert(good_snr).reshape(self.spatial_shape).T]*self.nwave).T
+        indx = numpy.array([numpy.logical_not(good_snr).reshape(self.spatial_shape).T]*self.nwave).T
         mask[indx] = self.bitmask.turn_on(mask[indx], flag='LOW_SNR')
 
         return mask
@@ -705,7 +705,7 @@ class SpatiallyBinnedSpectra:
                 else angstroms_per_pixel(self.cube.wave, log=self.cube.log)
         _response_func = self.cube.interpolate_to_match(self.rdxqa.method.response)
         # Get the signal
-        response_integral = numpy.sum(numpy.invert(numpy.ma.getmaskarray(_stack_flux))
+        response_integral = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(_stack_flux))
                                         * (_response_func*dw)[None,:], axis=1)
         bin_data['SIGNAL'] = numpy.ma.divide(numpy.ma.sum(_stack_flux*(_response_func*dw)[None,:],
                                                           axis=1), response_integral).filled(0.0)
@@ -921,10 +921,10 @@ class SpatiallyBinnedSpectra:
                                                         out_mask=map_mask)
         drp_bad = map_mask > 0
         # Add the spectra with low spectral coverage
-        indx = numpy.invert(good_fgoodpix.reshape(self.spatial_shape)) & numpy.invert(drp_bad)
+        indx = numpy.logical_not(good_fgoodpix.reshape(self.spatial_shape)) & numpy.logical_not(drp_bad)
         map_mask[indx] = self.bitmask.turn_on(map_mask[indx], 'LOW_SPECCOV')
         # Add the spectra with low S/N
-        indx = numpy.invert(good_snr.reshape(self.spatial_shape)) & numpy.invert(drp_bad)
+        indx = numpy.logical_not(good_snr.reshape(self.spatial_shape)) & numpy.logical_not(drp_bad)
         map_mask[indx] = self.bitmask.turn_on(map_mask[indx], 'LOW_SNR')
 
         # Fill the covariance HDUs
@@ -1393,11 +1393,11 @@ class SpatiallyBinnedSpectra:
 
         # Construct the mask
         stack_mask = numpy.zeros(stack_flux.shape, dtype=self.bitmask.minimum_dtype())
-        indx = numpy.invert(stack_npix>0)
+        indx = numpy.logical_not(stack_npix>0)
         stack_mask[indx] = self.bitmask.turn_on(stack_mask[indx], ['NONE_IN_STACK', 'NO_STDDEV'])
-        indx = numpy.invert(stack_npix>1)
+        indx = numpy.logical_not(stack_npix>1)
         stack_mask[indx] = self.bitmask.turn_on(stack_mask[indx], 'NO_STDDEV')
-        indx = numpy.invert(stack_ivar>0)
+        indx = numpy.logical_not(stack_ivar>0)
         stack_mask[indx] = self.bitmask.turn_on(stack_mask[indx], ['IVARINVALID', 'DIDNOTUSE'])
 
         #---------------------------------------------------------------
@@ -1719,7 +1719,7 @@ class SpatiallyBinnedSpectra:
 
         # Account for any missing bins
         valid_input_bin = numpy.ones(_input_bins.size, dtype=bool) if len(self.missing_bins) == 0 \
-                            else numpy.invert([ ib in self.missing_bins for ib in _input_bins ])
+                            else numpy.logical_not([ ib in self.missing_bins for ib in _input_bins ])
         if not numpy.all(valid_input_bin):
             warnings.warn('Input bin IDs include missing bins.  Returned as -1.')
         _input_bins = _input_bins[valid_input_bin]

--- a/mangadap/proc/spectralfitting.py
+++ b/mangadap/proc/spectralfitting.py
@@ -328,7 +328,7 @@ class EmissionLineFit(SpectralFitting):
             return bins_to_fit
 
         # Determine which spectra have a valid stellar continuum fit
-        indx = numpy.invert(stellar_continuum.bitmask.flagged(
+        indx = numpy.logical_not(stellar_continuum.bitmask.flagged(
                                     stellar_continuum['PAR'].data['MASK'],
                                     flag=[ 'NO_FIT', 'INSUFFICIENT_DATA', 'FIT_FAILED']))
         with_good_continuum = numpy.zeros(binned_spectra.nbins, dtype=bool)
@@ -422,7 +422,7 @@ class EmissionLineFit(SpectralFitting):
             ivar = binned_spectra.copy_to_masked_array(ext='IVAR', flag=flags)
             sres = binned_spectra.copy_to_array(ext='SPECRES')
             sres = numpy.apply_along_axis(interpolate_masked_vector, 1,
-                                    numpy.ma.MaskedArray(sres, mask=numpy.invert(sres > 0)))
+                                    numpy.ma.MaskedArray(sres, mask=numpy.logical_not(sres > 0)))
         nspec = flux.shape[0]
 
         # Convert inverse variance to error
@@ -523,7 +523,7 @@ class EmissionLineFit(SpectralFitting):
             return flux, None
 
         # Get where the continuum is masked but the spectra are not
-        no_continuum = numpy.invert(numpy.ma.getmaskarray(flux)) & numpy.ma.getmaskarray(continuum)
+        no_continuum = numpy.logical_not(numpy.ma.getmaskarray(flux)) & numpy.ma.getmaskarray(continuum)
 
         # Subtract the continuum (ensure output is a masked array)
         continuum_subtracted_flux = numpy.ma.subtract(flux, continuum)
@@ -743,8 +743,8 @@ class EmissionLineFit(SpectralFitting):
 
         # Flag non-positive measurements
         if bitmask is not None:
-            model_eml_par['MASK'][numpy.invert(pos)] \
-                    = bitmask.turn_on(model_eml_par['MASK'][numpy.invert(pos)],
+            model_eml_par['MASK'][numpy.logical_not(pos)] \
+                    = bitmask.turn_on(model_eml_par['MASK'][numpy.logical_not(pos)],
                                       'NON_POSITIVE_CONTINUUM')
 
     @staticmethod
@@ -871,7 +871,7 @@ class EmissionLineFit(SpectralFitting):
 
         # Get the fitted line amplitude
         sigma_ang = model_eml_par['KIN'][:,:,1]*sample_wave/astropy.constants.c.to('km/s').value
-        sigma_ang = numpy.ma.MaskedArray(sigma_ang, mask=numpy.invert(sigma_ang > 0))
+        sigma_ang = numpy.ma.MaskedArray(sigma_ang, mask=numpy.logical_not(sigma_ang > 0))
         model_eml_par['AMP'] = numpy.ma.divide(model_eml_par['FLUX'], sigma_ang).filled(0.0) \
                                     / numpy.sqrt(2*numpy.pi)
 
@@ -889,9 +889,9 @@ class EmissionLineFit(SpectralFitting):
         noise = numpy.zeros_like(model_eml_par['AMP'], dtype=float)
         for i in range(nspec):
             _bluenoise = passband_median(_wave, _ferr[i,:], passband=_bluebands[i,:,:])
-            _bluenoise = numpy.ma.MaskedArray(_bluenoise, mask=numpy.invert(_bluenoise > 0))
+            _bluenoise = numpy.ma.MaskedArray(_bluenoise, mask=numpy.logical_not(_bluenoise > 0))
             _rednoise = passband_median(_wave, _ferr[i,:], passband=_redbands[i,:,:])
-            _rednoise = numpy.ma.MaskedArray(_rednoise, mask=numpy.invert(_rednoise > 0))
+            _rednoise = numpy.ma.MaskedArray(_rednoise, mask=numpy.logical_not(_rednoise > 0))
             noise[i,:] = ((_bluenoise + _rednoise)/2.).filled(0.0)
         model_eml_par['ANR'] = numpy.ma.divide(model_eml_par['AMP'], noise).filled(0.0)
 

--- a/mangadap/proc/stellarcontinuummodel.py
+++ b/mangadap/proc/stellarcontinuummodel.py
@@ -517,7 +517,7 @@ class StellarContinuumModel:
             `numpy.ndarray`_: Sorted list of missing models.
         """
         good_snr = self.binned_spectra.above_snr_limit(self.method['minimum_snr'], debug=debug)
-        return numpy.sort(self.binned_spectra['BINS'].data['BINID'][numpy.invert(good_snr)].tolist()
+        return numpy.sort(self.binned_spectra['BINS'].data['BINID'][numpy.logical_not(good_snr)].tolist()
                                 + self.binned_spectra.missing_bins) 
 
     def _construct_2d_hdu(self, good_snr, model_flux, model_mask, model_par):
@@ -555,7 +555,7 @@ class StellarContinuumModel:
         indx = self.binned_spectra.bitmask.flagged(self.binned_spectra['MAPMASK'].data, 'FORESTAR')
         map_mask[indx] = self.bitmask.turn_on(map_mask[indx], 'FORESTAR')
         # Get the bins that were blow the S/N limit
-        indx = numpy.invert(DAPFitsUtil.reconstruct_map(self.spatial_shape,
+        indx = numpy.logical_not(DAPFitsUtil.reconstruct_map(self.spatial_shape,
                                                         self.binned_spectra['BINID'].data.ravel(),
                                                         good_snr, dtype='bool')) & (map_mask == 0)
         map_mask[indx] = self.bitmask.turn_on(map_mask[indx], 'LOW_SNR')
@@ -1075,7 +1075,7 @@ class StellarContinuumModel:
             raise TypeError('Provided template replacements must have type TemplateLibrary.')
 
         # Only the selected models are constructed, others are masked
-        select = numpy.invert(self.bitmask.flagged(self.hdu['PAR'].data['MASK'],
+        select = numpy.logical_not(self.bitmask.flagged(self.hdu['PAR'].data['MASK'],
                                             flag=['NO_FIT', 'FIT_FAILED', 'INSUFFICIENT_DATA']))
         templates = self.method['fitpar']['template_library'] if replacement_templates is None \
                                             else replacement_templates

--- a/mangadap/proc/templatelibrary.py
+++ b/mangadap/proc/templatelibrary.py
@@ -681,7 +681,7 @@ class TemplateLibrary:
             if wave_.size != npix:
                 mask[i,wave_.size:] = self.bitmask.turn_on(mask[i,wave_.size:],'NO_DATA')
             if self.library['lower_flux_limit'] is not None:
-                indx = numpy.invert( flux_ > self.library['lower_flux_limit'] )
+                indx = numpy.logical_not( flux_ > self.library['lower_flux_limit'] )
                 mask[i,indx] = self.bitmask.turn_on(mask[i,indx], 'FLUX_INVALID')
             if self.library['wave_limit'] is not None \
                     and self.library['wave_limit'][0] is not None:
@@ -773,7 +773,7 @@ class TemplateLibrary:
             `numpy.ndarray`_: Two-element vector with wavelengths of
             the first and last valid pixels.
         """
-        indx = numpy.where(numpy.invert(self.bitmask.flagged(self.hdu['MASK'].data, flag=flag)))
+        indx = numpy.where(numpy.logical_not(self.bitmask.flagged(self.hdu['MASK'].data, flag=flag)))
         return numpy.array([numpy.amin(self.hdu['WAVE'].data[indx]),
                             numpy.amax(self.hdu['WAVE'].data[indx])]).astype(float)
 
@@ -883,7 +883,7 @@ class TemplateLibrary:
             self.bitmask.turn_on(self.hdu['MASK'].data[res_mask == 1], 'SPECRES_LOW')
 
         # Mask any pixels where the template flux is 0 or below
-        indx = numpy.invert(self.hdu['FLUX'].data > 0)
+        indx = numpy.logical_not(self.hdu['FLUX'].data > 0)
         if numpy.any(indx):
             self.hdu['MASK'].data[indx] = self.bitmask.turn_on(self.hdu['MASK'].data[indx],
                                                                'SPECRES_NOFLUX')
@@ -1075,7 +1075,7 @@ class TemplateLibrary:
         # Normalize the templates to the mean flux value after excluding
         # any flagged pixels.
         if renormalize:
-            indx = numpy.invert(self.bitmask.flagged(mask, flag=['NO_DATA', 'WAVE_INVALID', 
+            indx = numpy.logical_not(self.bitmask.flagged(mask, flag=['NO_DATA', 'WAVE_INVALID', 
                                                                  'FLUX_INVALID']))
             if numpy.sum(indx) == 0:
                 if not self.quiet:
@@ -1282,7 +1282,7 @@ class TemplateLibrary:
                 # Copy the spectral resolution to a masked array
                 self.sres = cube.copy_to_masked_array(attr='sres')
                 # Only use the spectra that are not fully masked
-                indx = numpy.sum(numpy.invert(numpy.ma.getmaskarray(self.sres)), axis=1) > 0
+                indx = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(self.sres)), axis=1) > 0
                 # Get the median resolution
                 self.sres = numpy.median(self.sres.data[indx], axis=0)
                 # Instantiate the resolution object

--- a/mangadap/proc/util.py
+++ b/mangadap/proc/util.py
@@ -381,7 +381,7 @@ def replace_with_data_from_nearest_coo(coo, data, replace):
         return data.copy()
 
     # Use the coordinates to replace to set the KDTree reference grid
-    do_not_replace = numpy.invert(_replace)
+    do_not_replace = numpy.logical_not(_replace)
     kd = spatial.KDTree(_coo[do_not_replace,:])
 
     # Get the indices of the nearest data points

--- a/mangadap/scripts/dapall_qa.py
+++ b/mangadap/scripts/dapall_qa.py
@@ -73,8 +73,8 @@ def ew_d4000(drpall, dapall, daptype, eml, spi, ofile=None):
     ha_bd = ha_indx & is_critical
     hd_bd = hd_indx & is_critical
 
-    ha_gd = ha_indx & numpy.invert(is_critical)
-    hd_gd = hd_indx & numpy.invert(is_critical)
+    ha_gd = ha_indx & numpy.logical_not(is_critical)
+    hd_gd = hd_indx & numpy.logical_not(is_critical)
 
     mass_lim = [1e9, 7e11]
     d4_lim = [0.9, 2.3]
@@ -173,8 +173,8 @@ def mass_lha(drpall, dapall, daptype, eml, ofile=None):
     loew_bd =  loew_indx & is_critical
     hiew_bd =  hiew_indx & is_critical
 
-    loew_gd =  loew_indx & numpy.invert(is_critical)
-    hiew_gd =  hiew_indx & numpy.invert(is_critical)
+    loew_gd =  loew_indx & numpy.logical_not(is_critical)
+    hiew_gd =  hiew_indx & numpy.logical_not(is_critical)
 
 
     mass_lim = [1e8, 1e12]
@@ -239,7 +239,7 @@ def mass_sigma(drpall, dapall, daptype, ofile=None):
 
     is_critical = DAPQualityBitMask().flagged(dapall['DAPQUAL'], 'CRITICAL')
     bd =  indx & is_critical
-    gd =  indx & numpy.invert(is_critical)
+    gd =  indx & numpy.logical_not(is_critical)
 
     rekpc = dapall['NSA_ELPETRO_TH50_R']*numpy.radians(1/3600)*1e3*dapall['ADIST_Z']
 
@@ -327,8 +327,8 @@ def velocity_gradient(drpall, dapall, daptype, eml, ofile=None):
     ha_bd =  ha_indx & is_critical
     st_bd =  st_indx & is_critical
 
-    ha_gd =  ha_indx & numpy.invert(is_critical)
-    st_gd =  st_indx & numpy.invert(is_critical)
+    ha_gd =  ha_indx & numpy.logical_not(is_critical)
+    st_gd =  st_indx & numpy.logical_not(is_critical)
 
     mass_lim = [2e8, 5e11]
     velw_lim = [30,  4000]
@@ -440,7 +440,7 @@ def mgfe_hbeta(drpall, dapall, daptype, spi, ofile=None):
 
     is_critical = DAPQualityBitMask().flagged(dapall['DAPQUAL'], 'CRITICAL')
     bd =  indx & is_critical
-    gd =  indx & numpy.invert(is_critical)
+    gd =  indx & numpy.logical_not(is_critical)
 
     mgfe = numpy.ma.sqrt(dapall['SPECINDEX_1RE'][:,spi['Mgb']]
                             * (0.72*dapall['SPECINDEX_1RE'][:,spi['Fe5270']] 
@@ -500,7 +500,7 @@ def radial_coverage_histogram(dapall, daptype, ofile=None):
     # Must have finished, be of the correct daptype, and *not* be
     # critical
     indx = (dapall['DAPDONE'] == 1) & (dapall['DAPTYPE'] == daptype) \
-                & numpy.invert(DAPQualityBitMask().flagged(dapall['DAPQUAL'], 'CRITICAL'))
+                & numpy.logical_not(DAPQualityBitMask().flagged(dapall['DAPQUAL'], 'CRITICAL'))
 
     # Get the range
     arcsec_rng = growth_lim(dapall['RCOV90'][indx], 0.99, fac=1.1)
@@ -516,7 +516,7 @@ def radial_coverage_histogram(dapall, daptype, ofile=None):
     primaryplus = targ1bm.flagged(dapall['MNGTARG1'][indx],
                                   flag=['PRIMARY_v1_2_0', 'COLOR_ENHANCED_v1_2_0'])
     secondary = targ1bm.flagged(dapall['MNGTARG1'][indx], flag='SECONDARY_v1_2_0')
-    other = numpy.invert(ancillary) & numpy.invert(primaryplus) & numpy.invert(secondary)
+    other = numpy.logical_not(ancillary) & numpy.logical_not(primaryplus) & numpy.logical_not(secondary)
 
     print('Num. of observations with 90% coverage <1 arcsec: {0}'.format(
             numpy.sum(dapall['RCOV90'][indx] < 1)))
@@ -617,8 +617,8 @@ def redshift_distribution(dapall, daptype, ofile=None):
     ns_bd = ns_indx & is_critical
     gs_bd = gs_indx & is_critical
 
-    ns_gd = ns_indx & numpy.invert(is_critical)
-    gs_gd = gs_indx & numpy.invert(is_critical)
+    ns_gd = ns_indx & numpy.logical_not(is_critical)
+    gs_gd = gs_indx & numpy.logical_not(is_critical)
 
 
     font = { 'size' : 14 }

--- a/mangadap/scripts/fit_residuals.py
+++ b/mangadap/scripts/fit_residuals.py
@@ -78,9 +78,9 @@ def gmr_data(cube, min_frac=0.8):
         ext_list = [h.name for h in hdu]
         if 'GIMG' in ext_list and 'RIMG' in ext_list:
             return -2.5*numpy.ma.log10(numpy.ma.MaskedArray(hdu['GIMG'].data,
-                                                            mask=numpy.invert(hdu['GIMG'].data>0))
+                                                            mask=numpy.logical_not(hdu['GIMG'].data>0))
                                     / numpy.ma.MaskedArray(hdu['RIMG'].data,
-                                                           mask=numpy.invert(hdu['RIMG'].data>0)))
+                                                           mask=numpy.logical_not(hdu['RIMG'].data>0)))
 
     # Next, try to create it from scratch
     g_file = defaults.dap_data_root() / 'filter_response' / 'gunn_2001_g_response.db'
@@ -176,7 +176,7 @@ def get_stellar_continuum_fom_maps(cube, dapmaps):
     # Get the associated S/N and fit metrics
     maps_hdu = fits.open(str(dapmaps))
     snrg = numpy.ma.MaskedArray(maps_hdu['BIN_SNR'].data,
-                                mask=numpy.invert(maps_hdu['BIN_SNR'].data > 0))
+                                mask=numpy.logical_not(maps_hdu['BIN_SNR'].data > 0))
     mask = maps_hdu['STELLAR_VEL_MASK'].data > 0
     rms = numpy.ma.MaskedArray(maps_hdu['STELLAR_FOM'].data[0,:,:], mask=mask)
     frms = numpy.ma.MaskedArray(maps_hdu['STELLAR_FOM'].data[1,:,:], mask=mask)
@@ -257,13 +257,13 @@ def get_emission_line_fom_maps(dapmaps):
 
     # Get the associated S/N and fit metrics
     rms = numpy.ma.MaskedArray(maps_hdu['EMLINE_FOM'].data[0,:,:])
-    rms[numpy.invert(rms > 0)] = numpy.ma.masked
+    rms[numpy.logical_not(rms > 0)] = numpy.ma.masked
     frms = numpy.ma.MaskedArray(maps_hdu['EMLINE_FOM'].data[1,:,:])
-    frms[numpy.invert(frms > 0)] = numpy.ma.masked
+    frms[numpy.logical_not(frms > 0)] = numpy.ma.masked
     rchi2 = numpy.ma.MaskedArray(maps_hdu['EMLINE_FOM'].data[2,:,:])
-    rchi2[numpy.invert(rchi2 > 0)] = numpy.ma.masked
+    rchi2[numpy.logical_not(rchi2 > 0)] = numpy.ma.masked
     chi_grw = numpy.ma.MaskedArray(maps_hdu['EMLINE_FOM'].data[6:,:,:])
-    chi_grw[numpy.invert(chi_grw > 0)] = numpy.ma.masked
+    chi_grw[numpy.logical_not(chi_grw > 0)] = numpy.ma.masked
 
     extent = map_extent(maps_hdu, 'SPX_MFLUX')
 
@@ -278,7 +278,7 @@ def fom_lambda(name, wave, flux, error, model, fit='sc', wave_limits=None, ofile
         error[indx,:] = numpy.ma.masked
         model[indx,:] = numpy.ma.masked
     else:
-        indx = numpy.arange(len(wave))[numpy.any(numpy.invert(model.mask), axis=1)]
+        indx = numpy.arange(len(wave))[numpy.any(numpy.logical_not(model.mask), axis=1)]
         wave_limits = [wave[indx[0]], wave[indx[-1]]]
 
     nspec = flux.shape[1]

--- a/mangadap/scripts/plate_fit_qa.py
+++ b/mangadap/scripts/plate_fit_qa.py
@@ -89,7 +89,7 @@ def compile_data(dapver, analysis_path, daptype, plt):
             indx = indx[1:]
 
         mask = hdu['STELLAR_VEL_MASK'].data.ravel()[indx] > 0
-        indx = indx[numpy.invert(mask)]
+        indx = indx[numpy.logical_not(mask)]
 
         if len(indx) > 0:
             sc_pltifu += [ '{0}-{1}'.format(plt, ifu) ]
@@ -106,7 +106,7 @@ def compile_data(dapver, analysis_path, daptype, plt):
             uniq = uniq[1:]
             indx = indx[1:]
         mask = hdu['EMLINE_GFLUX_MASK'].data[eml['Ha-6564'],:,:].ravel()[indx] > 0
-        indx = indx[numpy.invert(mask)]
+        indx = indx[numpy.logical_not(mask)]
 
         if len(indx) > 0:
             el_pltifu += [ '{0}-{1}'.format(plt, ifu) ]

--- a/mangadap/scripts/ppxffit_qa.py
+++ b/mangadap/scripts/ppxffit_qa.py
@@ -492,9 +492,9 @@ def gmr_data(cube, min_frac=0.8):
         ext_list = [h.name for h in hdu]
         if 'GIMG' in ext_list and 'RIMG' in ext_list:
             return -2.5*numpy.ma.log10(numpy.ma.MaskedArray(hdu['GIMG'].data,
-                                                            mask=numpy.invert(hdu['GIMG'].data>0))
+                                                            mask=numpy.logical_not(hdu['GIMG'].data>0))
                                     / numpy.ma.MaskedArray(hdu['RIMG'].data,
-                                                           mask=numpy.invert(hdu['RIMG'].data>0)))
+                                                           mask=numpy.logical_not(hdu['RIMG'].data>0)))
 
     # Next, try to create it from scratch
     g_file = defaults.dap_data_root() / 'filter_response' / 'gunn_2001_g_response.db'
@@ -562,9 +562,9 @@ def rdxqa_data(cube, rdxqa_method, output_path):
         spatial_shape = (int(numpy.sqrt(hdu['SPECTRUM'].data['SNR'].size)),)*2
         fgood_map = hdu['SPECTRUM'].data['FGOODPIX'].reshape(spatial_shape).T
         signal_map = numpy.ma.MaskedArray(hdu['SPECTRUM'].data['SIGNAL'].reshape(spatial_shape).T,
-                                          mask=numpy.invert(fgood_map > 0))
+                                          mask=numpy.logical_not(fgood_map > 0))
         snr_map = numpy.ma.MaskedArray(hdu['SPECTRUM'].data['SNR'].reshape(spatial_shape).T,
-                                       mask=numpy.invert(fgood_map > 0))
+                                       mask=numpy.logical_not(fgood_map > 0))
     return signal_map, snr_map
 
     
@@ -710,28 +710,28 @@ def ppxffit_qa_plot(cube, plan, method_dir, ref_dir, qa_dir, fwhm=None, tpl_flux
 
     # Map the continuum component data
     t_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), t, quiet=True)
-    t_map = numpy.ma.MaskedArray(t_map, mask=numpy.invert(t_map > 0))
+    t_map = numpy.ma.MaskedArray(t_map, mask=numpy.logical_not(t_map > 0))
 
     dt_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), dt, quiet=True)
-    dt_map = numpy.ma.MaskedArray(dt_map, mask=numpy.invert(dt_map > 0)) #/t_map
+    dt_map = numpy.ma.MaskedArray(dt_map, mask=numpy.logical_not(dt_map > 0)) #/t_map
 
     tn_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), tn, quiet=True)
-    tn_map = numpy.ma.MaskedArray(tn_map, mask=numpy.invert(tn_map > 0))
+    tn_map = numpy.ma.MaskedArray(tn_map, mask=numpy.logical_not(tn_map > 0))
 
     dtn_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), dtn, quiet=True)
-    dtn_map = numpy.ma.MaskedArray(dtn_map, mask=numpy.invert(dtn_map > 0)) #/tn_map
+    dtn_map = numpy.ma.MaskedArray(dtn_map, mask=numpy.logical_not(dtn_map > 0)) #/tn_map
 
     a_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), a, quiet=True)
-    a_map = numpy.ma.MaskedArray(a_map, mask=numpy.invert(a_map > 0))
+    a_map = numpy.ma.MaskedArray(a_map, mask=numpy.logical_not(a_map > 0))
 
     da_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), da, quiet=True)
-    da_map = numpy.ma.MaskedArray(da_map, mask=numpy.invert(da_map > 0)) #/a_map
+    da_map = numpy.ma.MaskedArray(da_map, mask=numpy.logical_not(da_map > 0)) #/a_map
 
     an_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), an, quiet=True)
-    an_map = numpy.ma.MaskedArray(an_map, mask=numpy.invert(an_map > 0))
+    an_map = numpy.ma.MaskedArray(an_map, mask=numpy.logical_not(an_map > 0))
 
     dan_map = DAPFitsUtil.reconstruct_map(binid_map.shape, binid_map.ravel(), dan, quiet=True)
-    dan_map = numpy.ma.MaskedArray(dan_map, mask=numpy.invert(dan_map > 0)) #/an_map
+    dan_map = numpy.ma.MaskedArray(dan_map, mask=numpy.logical_not(dan_map > 0)) #/an_map
 
     _, directory, file = dapfits.default_paths(cube, method=plan['key'], output_path=method_dir)
     maps_file = directory / file

--- a/mangadap/scripts/spotcheck_dap_maps.py
+++ b/mangadap/scripts/spotcheck_dap_maps.py
@@ -129,61 +129,61 @@ def spotcheck_images(cube, plan, method_dir, ref_dir, qa_dir, fwhm=None):
 
     # 68% growth of the absolute value of the fractional residuals
     scfres = numpy.ma.MaskedArray(hdu['STELLAR_FOM'].data.copy()[3,:,:],
-                                  mask=numpy.invert(hdu['STELLAR_FOM'].data[3,:,:] > 0))
+                                  mask=numpy.logical_not(hdu['STELLAR_FOM'].data[3,:,:] > 0))
     # Reduced chi-square
     scrchi = numpy.ma.MaskedArray(hdu['STELLAR_FOM'].data.copy()[2,:,:],
-                                  mask=numpy.invert(hdu['STELLAR_FOM'].data[2,:,:] > 0))
+                                  mask=numpy.logical_not(hdu['STELLAR_FOM'].data[2,:,:] > 0))
 
     strvel = numpy.ma.MaskedArray(hdu['STELLAR_VEL'].data.copy(),
                                   mask=bm.flagged(hdu['STELLAR_VEL_MASK'].data, 'DONOTUSE'))
     ustrvel = numpy.ma.MaskedArray(hdu['STELLAR_VEL'].data.copy(),
-                                  mask=numpy.invert(bm.flagged(hdu['STELLAR_VEL_MASK'].data,
+                                  mask=numpy.logical_not(bm.flagged(hdu['STELLAR_VEL_MASK'].data,
                                                                'UNRELIABLE')))
-    ustrvel[numpy.invert(numpy.ma.getmaskarray(ustrvel))] = 0.0
+    ustrvel[numpy.logical_not(numpy.ma.getmaskarray(ustrvel))] = 0.0
     strsig = numpy.ma.MaskedArray(hdu['STELLAR_SIGMA'].data.copy(),
                                   mask=bm.flagged(hdu['STELLAR_SIGMA_MASK'].data, 'DONOTUSE'))
     ustrsig = numpy.ma.MaskedArray(hdu['STELLAR_SIGMA'].data.copy(),
-                                  mask=numpy.invert(bm.flagged(hdu['STELLAR_SIGMA_MASK'].data,
+                                  mask=numpy.logical_not(bm.flagged(hdu['STELLAR_SIGMA_MASK'].data,
                                                                'UNRELIABLE')))
-    ustrsig[numpy.invert(numpy.ma.getmaskarray(ustrsig))] = 0.0
+    ustrsig[numpy.logical_not(numpy.ma.getmaskarray(ustrsig))] = 0.0
 
     hasflx = numpy.ma.MaskedArray(hdu['EMLINE_SFLUX'].data.copy()[emline['Ha-6564'],:,:],
             mask=bm.flagged(hdu['EMLINE_SFLUX_MASK'].data[emline['Ha-6564'],:,:], 'DONOTUSE'))
     uhasflx = numpy.ma.MaskedArray(hdu['EMLINE_SFLUX'].data.copy()[emline['Ha-6564'],:,:],
-          mask=numpy.invert(bm.flagged(hdu['EMLINE_SFLUX_MASK'].data[emline['Ha-6564'],:,:],
+          mask=numpy.logical_not(bm.flagged(hdu['EMLINE_SFLUX_MASK'].data[emline['Ha-6564'],:,:],
                                        'UNRELIABLE')))
-    uhasflx[numpy.invert(numpy.ma.getmaskarray(uhasflx))] = 0.0
+    uhasflx[numpy.logical_not(numpy.ma.getmaskarray(uhasflx))] = 0.0
     hagflx = numpy.ma.MaskedArray(hdu['EMLINE_GFLUX'].data.copy()[emline['Ha-6564'],:,:],
           mask=bm.flagged(hdu['EMLINE_GFLUX_MASK'].data[emline['Ha-6564'],:,:], 'DONOTUSE'))
     uhagflx = numpy.ma.MaskedArray(hdu['EMLINE_GFLUX'].data.copy()[emline['Ha-6564'],:,:],
-          mask=numpy.invert(bm.flagged(hdu['EMLINE_GFLUX_MASK'].data[emline['Ha-6564'],:,:],
+          mask=numpy.logical_not(bm.flagged(hdu['EMLINE_GFLUX_MASK'].data[emline['Ha-6564'],:,:],
                                        'UNRELIABLE')))
-    uhagflx[numpy.invert(numpy.ma.getmaskarray(uhagflx))] = 0.0
+    uhagflx[numpy.logical_not(numpy.ma.getmaskarray(uhagflx))] = 0.0
     hagvel = numpy.ma.MaskedArray(hdu['EMLINE_GVEL'].data.copy()[emline['Ha-6564'],:,:],
           mask=bm.flagged(hdu['EMLINE_GVEL_MASK'].data[emline['Ha-6564'],:,:], 'DONOTUSE'))
     uhagvel = numpy.ma.MaskedArray(hdu['EMLINE_GVEL'].data.copy()[emline['Ha-6564'],:,:],
-          mask=numpy.invert(bm.flagged(hdu['EMLINE_GVEL_MASK'].data[emline['Ha-6564'],:,:],
+          mask=numpy.logical_not(bm.flagged(hdu['EMLINE_GVEL_MASK'].data[emline['Ha-6564'],:,:],
                                        'UNRELIABLE')))
-    uhagvel[numpy.invert(numpy.ma.getmaskarray(uhagvel))] = 0.0
+    uhagvel[numpy.logical_not(numpy.ma.getmaskarray(uhagvel))] = 0.0
     hagsig = numpy.ma.MaskedArray(hdu['EMLINE_GSIGMA'].data.copy()[emline['Ha-6564'],:,:],
         mask=bm.flagged(hdu['EMLINE_GSIGMA_MASK'].data[emline['Ha-6564'],:,:], 'DONOTUSE'))
     uhagsig = numpy.ma.MaskedArray(hdu['EMLINE_GSIGMA'].data.copy()[emline['Ha-6564'],:,:],
-        mask=numpy.invert(bm.flagged(hdu['EMLINE_GSIGMA_MASK'].data[emline['Ha-6564'],:,:],
+        mask=numpy.logical_not(bm.flagged(hdu['EMLINE_GSIGMA_MASK'].data[emline['Ha-6564'],:,:],
                                      'UNRELIABLE')))
-    uhagsig[numpy.invert(numpy.ma.getmaskarray(uhagsig))] = 0.0
+    uhagsig[numpy.logical_not(numpy.ma.getmaskarray(uhagsig))] = 0.0
 
     hbsflx = numpy.ma.MaskedArray(hdu['EMLINE_SFLUX'].data.copy()[emline['Hb-4862'],:,:],
           mask=bm.flagged(hdu['EMLINE_SFLUX_MASK'].data[emline['Hb-4862'],:,:], 'DONOTUSE'))
     uhbsflx = numpy.ma.MaskedArray(hdu['EMLINE_SFLUX'].data.copy()[emline['Hb-4862'],:,:],
-          mask=numpy.invert(bm.flagged(hdu['EMLINE_SFLUX_MASK'].data[emline['Hb-4862'],:,:],
+          mask=numpy.logical_not(bm.flagged(hdu['EMLINE_SFLUX_MASK'].data[emline['Hb-4862'],:,:],
                                        'UNRELIABLE')))
-    uhbsflx[numpy.invert(numpy.ma.getmaskarray(uhbsflx))] = 0.0
+    uhbsflx[numpy.logical_not(numpy.ma.getmaskarray(uhbsflx))] = 0.0
     hbgflx = numpy.ma.MaskedArray(hdu['EMLINE_GFLUX'].data.copy()[emline['Hb-4862'],:,:],
           mask=bm.flagged(hdu['EMLINE_GFLUX_MASK'].data[emline['Hb-4862'],:,:], 'DONOTUSE'))
     uhbgflx = numpy.ma.MaskedArray(hdu['EMLINE_GFLUX'].data.copy()[emline['Hb-4862'],:,:],
-          mask=numpy.invert(bm.flagged(hdu['EMLINE_GFLUX_MASK'].data[emline['Hb-4862'],:,:],
+          mask=numpy.logical_not(bm.flagged(hdu['EMLINE_GFLUX_MASK'].data[emline['Hb-4862'],:,:],
                                        'UNRELIABLE')))
-    uhbgflx[numpy.invert(numpy.ma.getmaskarray(uhbgflx))] = 0.0
+    uhbgflx[numpy.logical_not(numpy.ma.getmaskarray(uhbgflx))] = 0.0
 
     specindex_available = True
     try:
@@ -197,17 +197,17 @@ def spotcheck_images(cube, plan, method_dir, ref_dir, qa_dir, fwhm=None):
                                 mask=bm.flagged(hdu['SPECINDEX_MASK'].data[specindex['D4000'],:,:],
                                                 'DONOTUSE'))
         ud4000 = numpy.ma.MaskedArray(hdu['SPECINDEX'].data.copy()[specindex['D4000'],:,:],
-                                mask=numpy.invert(bm.flagged(hdu['SPECINDEX_MASK'].data[
+                                mask=numpy.logical_not(bm.flagged(hdu['SPECINDEX_MASK'].data[
                                                       specindex['D4000'],:,:], 'UNRELIABLE')))
-        ud4000[numpy.invert(numpy.ma.getmaskarray(ud4000))] = 0.0
+        ud4000[numpy.logical_not(numpy.ma.getmaskarray(ud4000))] = 0.0
         dn4000 = numpy.ma.MaskedArray(hdu['SPECINDEX'].data.copy()[specindex['Dn4000'],:,:],
                                 mask=bm.flagged(hdu['SPECINDEX_MASK'].data[specindex['Dn4000'],:,:],
                                                 'DONOTUSE'))
         udn4000 = numpy.ma.MaskedArray(hdu['SPECINDEX'].data.copy()[specindex['Dn4000'],:,:],
-                                mask=numpy.invert(bm.flagged(
+                                mask=numpy.logical_not(bm.flagged(
                                         hdu['SPECINDEX_MASK'].data[specindex['Dn4000'],:,:],
                                         'UNRELIABLE')))
-        udn4000[numpy.invert(numpy.ma.getmaskarray(udn4000))] = 0.0
+        udn4000[numpy.logical_not(numpy.ma.getmaskarray(udn4000))] = 0.0
     else:
         output_shape = spxflx.shape
         d4000 = numpy.ma.masked_all(output_shape)

--- a/mangadap/spectra/rowstackedspectra.py
+++ b/mangadap/spectra/rowstackedspectra.py
@@ -280,7 +280,7 @@ class RowStackedSpectra:
                                                 missing_bins=missing_bins, unique_bins=unique_bins)
         # For this approach, the wavelengths masked should be
         # *identical* for all spectra
-        nwave = numpy.sum(numpy.invert(numpy.ma.getmaskarray(masked_data)), axis=1)
+        nwave = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(masked_data)), axis=1)
         # No masking should be present except for the wavelength range
         # meaning that the number of unmasked pixels at all spatial
         # positions should be the same.
@@ -492,7 +492,7 @@ class RowStackedSpectra:
             return numpy.ma.sum(flux*xpos*_response_func[None,:]*dw[None,:],axis=1)/norm, \
                     numpy.ma.sum(flux*ypos*_response_func[None,:]*dw[None,:],axis=1)/norm
 
-        norm = numpy.sum(numpy.invert(numpy.ma.getmaskarray(xpos))*_response_func[None,:]
+        norm = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(xpos))*_response_func[None,:]
                                 *dw[None,:], axis=1)
         return numpy.ma.sum(xpos*_response_func[None,:]*dw[None,:],axis=1)/norm, \
                     numpy.ma.sum(ypos*_response_func[None,:]*dw[None,:],axis=1)/norm
@@ -621,9 +621,9 @@ class RowStackedSpectra:
                                     axis=1) / norm
             return numpy.mean(cen_wave)
 
-        norm = numpy.ma.sum(numpy.invert(numpy.ma.getmaskarray(flux))
+        norm = numpy.ma.sum(numpy.logical_not(numpy.ma.getmaskarray(flux))
                             * _response_func[None,:] * dw[None,:], axis=1)
-        cen_wave = numpy.ma.sum(numpy.invert(numpy.ma.getmaskarray(flux)) * self.wave[None,:]
+        cen_wave = numpy.ma.sum(numpy.logical_not(numpy.ma.getmaskarray(flux)) * self.wave[None,:]
                                 * _response_func[None,:] * dw[None,:], axis=1) / norm
         return numpy.mean(cen_wave)
 
@@ -686,7 +686,7 @@ class RowStackedSpectra:
         _response_func = self.interpolate_to_match(response_func)
 
         # Get the moments
-        response_integral = numpy.sum(numpy.invert(numpy.ma.getmaskarray(flux))
+        response_integral = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(flux))
                                         * (_response_func*dw)[None,:], axis=1)
         signal = numpy.ma.divide(numpy.ma.sum(flux*(_response_func*dw)[None,:], axis=1),
                                  response_integral)
@@ -935,7 +935,7 @@ class RowStackedSpectra:
         # Do not include any pixels with zero inverse variance or
         # pixels that have been masked (either by the boolean mask
         # attribute or flagged with the provided mask bits)
-        mask = numpy.invert(self.ivar[:,self.rect_channel] > 0.0)
+        mask = numpy.logical_not(self.ivar[:,self.rect_channel] > 0.0)
         if rej_flag is not None and self.bitmask is not None:
             _rej_flag = rej_flag if isinstance(rej_flag, list) or rej_flag != 'any' else None
             mask |= self.bitmask.flagged(self.mask[:,self.rect_channel], flag=_rej_flag)
@@ -1414,7 +1414,7 @@ class RowStackedSpectra:
 
         # Rectify the data
         Tc = self.rect_T.sum(axis=1).flatten()
-        Tc[numpy.invert(Tc>0)] = 1.0                # Control for zeros
+        Tc[numpy.logical_not(Tc>0)] = 1.0                # Control for zeros
         # NOTE: This returns a numpy.ndarray instead of a numpy.matrix
         return numpy.asarray(numpy.sqrt(self.rect_T.dot(numpy.square(disp)) 
                                 / Tc).reshape(self.nx, self.ny))

--- a/mangadap/survey/dapall.py
+++ b/mangadap/survey/dapall.py
@@ -806,7 +806,7 @@ class DAPall:
         # Get the corrected indices; Unitless and ang units are treated
         # the same.
         mag = specindex_units == 'mag'
-        ang = numpy.invert(mag)
+        ang = numpy.logical_not(mag)
         specindex_corr[ang] = specindex[ang]*specindex_corr[ang]
         specindex_corr[mag] = specindex[mag]+specindex_corr[mag]
 
@@ -956,13 +956,13 @@ class DAPall:
             # Get the SRD-based S/N metric (independent of the DAP
             # method)
             r_re = numpy.ma.MaskedArray(dapmaps['SPX_ELLCOO'].data.copy()[1,:,:],
-                                        mask=numpy.invert(dapmaps['SPX_SNR'].data > 0))
+                                        mask=numpy.logical_not(dapmaps['SPX_SNR'].data > 0))
             db['SNR_MED'][i], db['SNR_RING'][i] = self._srd_snr_metric(dapmaps)
 
             # Get the mean surface brightness within 1 Re used by the
             # stellar-continuum fitting (independent of the DAP method)
             mflux = numpy.ma.MaskedArray(dapmaps['SPX_MFLUX'].data.copy(),
-                                         mask=numpy.invert(dapmaps['SPX_SNR'].data > 0))
+                                         mask=numpy.logical_not(dapmaps['SPX_SNR'].data > 0))
             within_1re = r_re < 1
             if numpy.sum(within_1re) == 0:
                 warnings.warn('No data within 1 Re!')

--- a/mangadap/tests/test_datacube.py
+++ b/mangadap/tests/test_datacube.py
@@ -91,7 +91,7 @@ def test_copyto():
 #    i = numpy.where([m['key'] == 'SNRG' for m in methods])[0]
 #    assert len(i) == 1, 'Could not find correct reduction assessment definition.'
     sig, var, snr = cube.flux_stats(response_func=method.response)
-    indx = ((sig > 0) & numpy.invert(numpy.ma.getmaskarray(sig))).data.ravel()
+    indx = ((sig > 0) & numpy.logical_not(numpy.ma.getmaskarray(sig))).data.ravel()
     ngood = numpy.sum(indx)
 
     # Select the spaxels with non-zero signal

--- a/mangadap/tests/test_emissionlinetemplates.py
+++ b/mangadap/tests/test_emissionlinetemplates.py
@@ -118,4 +118,9 @@ def test_multicomp_broadv():
             'There should be two groups of tied velocities; this is the second group'
 
 
+def test_build():
+    tpl_wave = numpy.logspace(*numpy.log10([3500., 10600.]), 6000)
+    etpl_sinst = numpy.full(tpl_wave.shape, 10., dtype=float)
+    emldb = EmissionLineDB.from_key('ELPMPL11')
+    etpl = EmissionLineTemplates(tpl_wave, etpl_sinst, emldb=emldb)
 

--- a/mangadap/tests/test_emlmoments.py
+++ b/mangadap/tests/test_emlmoments.py
@@ -43,8 +43,8 @@ def test_moments():
                                                 redshift=hdu['Z'].data, bitmask=elmombm)
 
     # Measure the EW based on the moments
-    include_band = numpy.array([numpy.invert(momdb.dummy)]*nspec) \
-                        & numpy.invert(elmombm.flagged(elmom['MASK'],
+    include_band = numpy.array([numpy.logical_not(momdb.dummy)]*nspec) \
+                        & numpy.logical_not(elmombm.flagged(elmom['MASK'],
                                                        flag=['BLUE_EMPTY', 'RED_EMPTY']))
     line_center = (1.0+hdu['Z'].data)[:,None]*momdb['restwave'][None,:]
     elmom['BMED'], elmom['RMED'], pos, elmom['EWCONT'], elmom['EW'], elmom['EWERR'] \
@@ -159,8 +159,8 @@ def test_moments_with_continuum():
                                                 bitmask=elmombm)
 
     # Measure the EW based on the moments
-    include_band = numpy.array([numpy.invert(momdb.dummy)]*nspec) \
-                        & numpy.invert(elmombm.flagged(elmom['MASK'],
+    include_band = numpy.array([numpy.logical_not(momdb.dummy)]*nspec) \
+                        & numpy.logical_not(elmombm.flagged(elmom['MASK'],
                                                        flag=['BLUE_EMPTY', 'RED_EMPTY']))
     line_center = (1.0+hdu['Z'].data)[:,None]*momdb['restwave'][None,:]
     elmom['BMED'], elmom['RMED'], pos, elmom['EWCONT'], elmom['EW'], elmom['EWERR'] \

--- a/mangadap/tests/test_rowstackedspectra.py
+++ b/mangadap/tests/test_rowstackedspectra.py
@@ -60,7 +60,7 @@ def test_copyto():
 #    i = numpy.where([m['key'] == 'SNRG' for m in methods])[0]
 #    assert len(i) == 1, 'Could not find correct reduction assessment definition.'
     sig, var, snr = rss.flux_stats(response_func=method.response)
-    indx = ((sig > 0) & numpy.invert(numpy.ma.getmaskarray(sig))).data.ravel()
+    indx = ((sig > 0) & numpy.logical_not(numpy.ma.getmaskarray(sig))).data.ravel()
     ngood = numpy.sum(indx)
 
     # Select the spaxels with non-zero signal

--- a/mangadap/util/extinction.py
+++ b/mangadap/util/extinction.py
@@ -72,7 +72,7 @@ def reddening_vector_calzetti(wave, ebv, rv=None):
 
     # Extinction curve
     ext = numpy.ma.zeros(_wave.size, dtype=float)
-    ext[numpy.invert(w1) & numpy.invert(w2)] = numpy.ma.masked
+    ext[numpy.logical_not(w1) & numpy.logical_not(w2)] = numpy.ma.masked
     ext[w1] = 2.659*(-1.857 + 1.040*k[w1]) + _rv
     ext[w2] = 2.659*(polyval(k[w2], [-2.156, 1.509, -0.198, 0.011])) + _rv
 
@@ -284,7 +284,7 @@ def reddening_vector_fm(wave, ebv, rv=None, coeffs=None):
     splpts_uv_ext, ext[w1] = uv_ext[:2], uv_ext[2:] 
 
     # Return if no optical/IR part
-    if numpy.sum(numpy.invert(w1)) == 0:
+    if numpy.sum(numpy.logical_not(w1)) == 0:
         return numpy.ma.power(10., 0.4*ext*ebv)
 
     # Optical/IR portion
@@ -303,7 +303,7 @@ def reddening_vector_fm(wave, ebv, rv=None, coeffs=None):
     interp = scipy.interpolate.CubicSpline(numpy.append(splpts_oi_k,splpts_uv_k),
                                            numpy.append(splpts_oi_ext,splpts_uv_ext),
                                            bc_type='natural')
-    w2 = numpy.invert(w1)
+    w2 = numpy.logical_not(w1)
     ext[w2] = interp(k[w2])
     return numpy.ma.power(10., 0.4*ext*ebv)
 

--- a/mangadap/util/fitsutil.py
+++ b/mangadap/util/fitsutil.py
@@ -442,16 +442,16 @@ class DAPFitsUtil:
         for i in range(narr):
             new_arr[i] = numpy.zeros(map_shape, dtype=_dtype[i])
             new_arr[i].ravel()[indx] = _arr[i][unique_bins[reconstruct[indx]]].copy()
-            s = numpy.sum(numpy.invert(numpy.isfinite(new_arr[i])))
+            s = numpy.sum(numpy.logical_not(numpy.isfinite(new_arr[i])))
             if s > 0:
                 print(i+1, narr)
                 print('dtype: ', _dtype[i])
-                a = numpy.sum(numpy.invert(numpy.isfinite(_arr[i][unique_bins[reconstruct[indx]]])))
+                a = numpy.sum(numpy.logical_not(numpy.isfinite(_arr[i][unique_bins[reconstruct[indx]]])))
                 print('not finite input:', a)
                 print('not finite output ravel:',
-                      numpy.sum(numpy.invert(numpy.isfinite(new_arr[i].ravel()[indx]))))
+                      numpy.sum(numpy.logical_not(numpy.isfinite(new_arr[i].ravel()[indx]))))
                 print('not finite output:', s)
-                nf = numpy.invert(numpy.isfinite(new_arr[i].ravel()[indx]))
+                nf = numpy.logical_not(numpy.isfinite(new_arr[i].ravel()[indx]))
                 print('inp: ', _arr[i][unique_bins[reconstruct[indx]]][nf])
                 print('out: ', new_arr[i].ravel()[indx][nf])
                 new_arr[i].ravel()[indx][nf] = 0.0
@@ -647,7 +647,7 @@ class DAPFitsUtil:
                                                        unique_bins=unique_bins)
         # For this approach, the wavelengths masked should be
         # *identical* for all spectra
-        nwave = numpy.sum(numpy.invert(numpy.ma.getmaskarray(masked_data))[0,:])
+        nwave = numpy.sum(numpy.logical_not(numpy.ma.getmaskarray(masked_data))[0,:])
         if nwave == 0:
             raise ValueError('Full wavelength range has been masked!')
         # Compression returns a flattened array, so it needs to be

--- a/mangadap/util/geometry.py
+++ b/mangadap/util/geometry.py
@@ -68,8 +68,8 @@ def polygon_winding_number(polygon, point):
     indx_r = dr[:,:,1] > 0
 
     wind = numpy.zeros((np, nvert), dtype=int)
-    wind[indx_l & numpy.invert(indx_r) & (dx < 0)] = -1
-    wind[numpy.invert(indx_l) & indx_r & (dx > 0)] = 1
+    wind[indx_l & numpy.logical_not(indx_r) & (dx < 0)] = -1
+    wind[numpy.logical_not(indx_l) & indx_r & (dx > 0)] = 1
 
     return numpy.sum(wind, axis=1)[0] if point.ndim == 1 else numpy.sum(wind, axis=1)
 

--- a/mangadap/util/mapping.py
+++ b/mangadap/util/mapping.py
@@ -408,7 +408,7 @@ def _match_map_arrays_sub_pixel_shift(arr1, ext1, arr2, ext2, dx, dy, swap=False
     # Pad and copy the array and its mask
     _arr2 = numpy.ma.masked_all(newshape, dtype=float)
     _arr2[add//2:add//2+arr2.shape[0],add//2:add//2+arr2.shape[1]] = arr2[:,:]
-    _gpm = numpy.invert(numpy.ma.getmaskarray(_arr2)).astype(float)
+    _gpm = numpy.logical_not(numpy.ma.getmaskarray(_arr2)).astype(float)
     # Shifts are in pixels, so adjust given the new coordinates
     dx -= add//2
     dy -= add//2

--- a/mangadap/util/pixelmask.py
+++ b/mangadap/util/pixelmask.py
@@ -142,7 +142,7 @@ class SpectralPixelMask(PixelMask):
         """
         if self.waverange is None:
             return self._empty_mask(wave, ny=nspec)
-        return numpy.invert(self._mask_coordinate_ranges(wave, self.waverange, ny=nspec))
+        return numpy.logical_not(self._mask_coordinate_ranges(wave, self.waverange, ny=nspec))
 
 
     def _artifact_mask(self, wave, nspec=None):
@@ -239,7 +239,7 @@ class SpectralPixelMask(PixelMask):
         """
 
         # Mask everything but the lines to ignore
-        indx = numpy.invert(self.emldb['action'] == 'i')
+        indx = numpy.logical_not(self.emldb['action'] == 'i')
         nbands = numpy.sum(indx)
         # No lines to mask
         if nbands == 0:
@@ -249,7 +249,7 @@ class SpectralPixelMask(PixelMask):
         _nsigma = self._check_eml_kin_argument(self.nsig)   # used to be (nsigma)
         if _nsigma is None:
             raise ValueError('Must provide the number of sigma to cover with the mask.')
-        if numpy.any(numpy.invert(_nsigma > 0)):
+        if numpy.any(numpy.logical_not(_nsigma > 0)):
             raise ValueError('Must provide a non-zero number of sigma for mask hal-fwidth.')
 
         # Get the mask centers
@@ -262,7 +262,7 @@ class SpectralPixelMask(PixelMask):
         # Get the mask widths
         _sigma = self._check_eml_kin_argument(sigma)
         halfwidth = _nsigma[indx] * (self.emldb['sig'][indx] if _sigma is None else _sigma[indx])
-        if numpy.any(numpy.invert(halfwidth > 0)):
+        if numpy.any(numpy.logical_not(halfwidth > 0)):
             raise ValueError('All emission-line mask half-widths must be larger than 0.')
 
         return numpy.array([ center*(1.0-halfwidth/astropy.constants.c.to('km/s').value),

--- a/mangadap/util/resolution.py
+++ b/mangadap/util/resolution.py
@@ -343,7 +343,7 @@ class SpectralResolution:
         """
 #        print('finalize b')
         indx = numpy.isclose(sig2_pd, 0.0)
-        nindx = numpy.invert(indx)
+        nindx = numpy.logical_not(indx)
         self.sig_pd = sig2_pd.copy()
         self.sig_pd[nindx] = sig2_pd[nindx]/numpy.sqrt(numpy.absolute(sig2_pd[nindx]))
         self.sig_pd[indx] = 0.0

--- a/mangadap/util/sampling.py
+++ b/mangadap/util/sampling.py
@@ -573,7 +573,7 @@ class Resample:
             # The mask and errors are always interpolated as a step function
             self.oute = None if self.e is None else self._resample_step(self.e, quad=True)
         
-            self.outf = self._resample_step(numpy.invert(self.m).astype(int)) \
+            self.outf = self._resample_step(numpy.logical_not(self.m).astype(int)) \
                             / numpy.diff(self.outborders)
 
         # Do not conserve the integral over the size of the pixel
@@ -745,7 +745,7 @@ class Resample:
         # Get the indices where the data should be reduced
         border = numpy.insert(numpy.zeros(_x.size, dtype=bool), indx,
                               numpy.ones(self.outborders.size, dtype=bool))
-        nn = numpy.where(numpy.invert(border))[0][::2]
+        nn = numpy.where(numpy.logical_not(border))[0][::2]
         k = numpy.zeros(len(combinedX), dtype=int)
         k[border] = numpy.arange(numpy.sum(border))
         k[nn-1] = k[nn-2]


### PR DESCRIPTION
As titled.

This also
 - replaces `numpy.invert` with `numpy.logical_not` everywhere
 - fixes a bug associated with radial binning
 - adds a short test for building emission-line templates